### PR TITLE
Support ansible-core>=2.16.0

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,2 +1,2 @@
 ---
-- include: timezone.yml
+- import_tasks: timezone.yml


### PR DESCRIPTION
Removed use of get_md5 when using stat module, See:
https://github.com/ansible/ansible/commit/d955fb1590efaaf996d7a48746e15f71cc65f583